### PR TITLE
Add features from clusterstack

### DIFF
--- a/thread-grep
+++ b/thread-grep
@@ -172,6 +172,26 @@ end
 # Extract and summarise threads matching a given criteria.
 class ThreadGrep
 
+  RESET_COLOR = "\033[0m"
+  STATE_COLORS = {
+    "RUNNABLE" => "\033[1;32m",
+    "UNKNOWN" => "\033[1;37m",
+    "BLOCKED" => "\033[1;33m",
+    "WAITING" => "\033[1;33m",
+    "TIMED_WAITING" => "\033[1;33m",
+  }
+  FRAME_COLORS = {
+    /at (javax?|sun|org\.mortbay|org\.restlet|org\.eclipse\.jetty)\./ => "\033[0;37m",
+    /- / => "\033[0;36m",
+  }
+
+  def frame_color(frame)
+    FRAME_COLORS.each do |regex, color|
+      return color if frame =~ regex
+    end
+    ""
+  end
+
   def main
     opts = Trollop::options do
       opt :match, "Show only threads matching pattern", :type => :string, :multi => true
@@ -179,6 +199,7 @@ class ThreadGrep
       opt :grep, "Only show stack lines matching pattern", :type => :string, :multi => true
       opt :lines, "Show <lines> lines per thread", :type => :int
       opt :cluster, "Groups threads with identical stack traces"
+      opt :color, "Colorize the output {never,auto,always}", :type => :string, :default => 'auto'
     end
 
     log_file = ARGV.fetch(0, nil)
@@ -188,6 +209,8 @@ class ThreadGrep
       $stderr.puts "  Type '-h' for options"
       exit
     end
+
+    use_color = opts[:color] == 'always' || (opts[:color] == 'auto' && STDOUT.tty?)
 
     thread_dump = ThreadDumpExtractor.new(log_file).call
 
@@ -208,11 +231,17 @@ class ThreadGrep
 
     groups.each do |stack, threads|
       threads.each do |thread|
-        puts "#{thread.name} (STATE: #{thread.state})"
+        print STATE_COLORS[thread.state] || "" if use_color
+        print "#{thread.name} (STATE: #{thread.state})"
+        print RESET_COLOR if use_color
+        puts ""
       end
       stack.each do |frame|
         next unless opts[:grep].all? {|pattern| frame =~ /#{pattern}/}
-        puts "  #{frame}"
+        print frame_color(frame) if use_color
+        print "  #{frame}"
+        print RESET_COLOR if use_color
+        puts ""
       end
       puts ""
     end


### PR DESCRIPTION
Coincidentally I wrote [something similar](https://github.com/ato/junk/blob/master/cuttrace) to thread-grep (but much dumber) a few months ago. It has a [companion script](https://github.com/ato/junk/blob/master/clusterstack) with two handy features I'm replicating here.

Firstly,  clustering threads with identical stack traces:
- makes it easy to see hotspots (many threads blocking on a slow web service, database, calculation etc)
- makes idle thread pools and the like much less verbose

For example here's a livelock due to an unsynchronized HashMap bug in the Restlet framework:

```
"1202479321@qtp-749039839-1245" prio=10 tid=0x00007f4054016800 nid=0x3e43 runnable [0x00007f40bedc6000] (STATE: RUNNABLE)
"213733551@qtp-749039839-1243" prio=10 tid=0x00007f4054006000 nid=0x3e40 runnable [0x00007f40b7ffc000] (STATE: RUNNABLE)
"1390834978@qtp-749039839-1242" prio=10 tid=0x00007f4054029800 nid=0x3e3f runnable [0x00007f40b7bf8000] (STATE: RUNNABLE)
"433169521@qtp-749039839-1241" prio=10 tid=0x00007f405001d000 nid=0x3e3e runnable [0x00007f40b6ce9000] (STATE: RUNNABLE)
"922076105@qtp-749039839-1240" prio=10 tid=0x00007f4050009800 nid=0x3e3d runnable [0x00007f40b70ed000] (STATE: RUNNABLE)
"1114517399@qtp-749039839-1236" prio=10 tid=0x00007f4054027800 nid=0x3d1c runnable [0x00007f40bd362000] (STATE: RUNNABLE)
"1229875577@qtp-749039839-1235" prio=10 tid=0x00007f405001a800 nid=0x3d1b runnable [0x00007f40b77f4000] (STATE: RUNNABLE)
"473895544@qtp-749039839-1234" prio=10 tid=0x00007f405001a000 nid=0x3d14 runnable [0x00007f40b7efb000] (STATE: RUNNABLE)
"1259511661@qtp-749039839-1227" prio=10 tid=0x00007f4050007800 nid=0x3c4d runnable [0x00007f40be2c2000] (STATE: RUNNABLE)
"1325934700@qtp-749039839-1223" prio=10 tid=0x00007f4050015800 nid=0x3b8a runnable [0x00007f40beec7000] (STATE: RUNNABLE)
"272071871@qtp-749039839-1201" prio=10 tid=0x00007f4054005000 nid=0x3587 runnable [0x00007f40bc51b000] (STATE: RUNNABLE)
  at java.util.WeakHashMap.getEntry(WeakHashMap.java:498)
  at java.util.WeakHashMap.containsKey(WeakHashMap.java:484)
  at org.restlet.engine.util.ImmutableDate.valueOf(ImmutableDate.java:66)
  at org.restlet.engine.util.DateUtils.unmodifiable(DateUtils.java:255)
  at org.restlet.representation.Representation.setExpirationDate(Representation.java:547)
  at org.restlet.engine.header.HeaderUtils.extractEntityHeaders(HeaderUtils.java:752)
  at org.restlet.ext.jaxrs.internal.util.Util.copyResponseHeaders(Util.java:330)
```

Secondly it colorizes the output by the state of threads (waiting/blocked vs running) and greys out boring standard library stack frames. Can be paged with:

```
thread-grep -c --color=always foo.log | less -r
```

Also handy to use with [ansi2html](http://www.pixelbeat.org/scripts/ansi2html.sh):

```
jstack $(pgrep -f suckyapp) > stack.txt
thread-grep --cluster --color=always stack.txt | ansi2html > ~/public_html/deadlock.html
echo 'http://example.org/deadlock.html' | mail -s'Fix this please' culprit@example.org
```
